### PR TITLE
Stop decoding BC1 punchthrough alpha in BC2&3

### DIFF
--- a/src/bcndecode.c
+++ b/src/bcndecode.c
@@ -85,7 +85,7 @@ static rgba decode_565(uint16_t x)
     return c;
 }
 
-static void decode_bc1_color(rgba *dst, const uint8_t *src)
+static void decode_bc1_color(rgba *dst, const uint8_t *src, int separate_alpha)
 {
     bc1_color col;
     rgba p[4];
@@ -101,7 +101,7 @@ static void decode_bc1_color(rgba *dst, const uint8_t *src)
     r1 = p[1].r;
     g1 = p[1].g;
     b1 = p[1].b;
-    if (col.c0 > col.c1)
+    if (col.c0 > col.c1 || separate_alpha)
     {
         p[2].r = (2 * r0 + 1 * r1) / 3;
         p[2].g = (2 * g0 + 1 * g1) / 3;
@@ -176,13 +176,13 @@ static void decode_bc3_alpha(char *dst, const uint8_t *src, int stride, int o)
 
 static void decode_bc1_block(rgba *col, const uint8_t *src)
 {
-    decode_bc1_color(col, src);
+    decode_bc1_color(col, src, 0);
 }
 
 static void decode_bc2_block(rgba *col, const uint8_t *src)
 {
     int n, bitI, byI, av;
-    decode_bc1_color(col, src + 8);
+    decode_bc1_color(col, src + 8, 1);
     for (n = 0; n < 16; n++)
     {
         bitI = n * 4;
@@ -195,7 +195,7 @@ static void decode_bc2_block(rgba *col, const uint8_t *src)
 
 static void decode_bc3_block(rgba *col, const uint8_t *src)
 {
-    decode_bc1_color(col, src + 8);
+    decode_bc1_color(col, src + 8, 1);
     decode_bc3_alpha((char *)col, src, sizeof(col[0]), 3);
 }
 
@@ -1119,7 +1119,7 @@ int main(int argc, char **argv) {
             case 5: flip = v; break;
         }
     }
-    
+
     int src_size = 4 * width * height;
     int dst_size = src_size;
     if (N == 1 || N == 4) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -336,11 +336,11 @@ fn swizzle_copy(swizzle: u8, dst: &mut [u8], src: &[u8], mut block_size: usize) 
 }
 
 fn decode_bc1_block(col: &mut [RGBA], source: &[u8]) {
-    decode_bc1_color(col, source);
+    decode_bc1_color(col, source, false);
 }
 
 fn decode_bc2_block(col: &mut [RGBA], source: &[u8]) {
-    decode_bc1_color(col, &source[8..]);
+    decode_bc1_color(col, &source[8..], true);
     for n in 0..16 {
         let bit_i: usize = n * 4;
         let by_i: usize = bit_i >> 3;
@@ -351,7 +351,7 @@ fn decode_bc2_block(col: &mut [RGBA], source: &[u8]) {
 }
 
 fn decode_bc3_block(col: &mut [RGBA], source: &[u8]) {
-    decode_bc1_color(col, &source[8..]);
+    decode_bc1_color(col, &source[8..], true);
     unsafe {
         decode_bc3_alpha(to_byte_ptr_mut(col), source, mem::size_of::<RGBA>(), 3);
     }
@@ -2210,7 +2210,7 @@ fn decode_565(x: u16) -> RGBA {
     };
 }
 
-fn decode_bc1_color(dst: &mut [RGBA], source: &[u8]) {
+fn decode_bc1_color(dst: &mut [RGBA], source: &[u8], separate_alpha: bool) {
     let mut col = Bc1Color::default();
     let mut p = [RGBA::default(); 4];
 
@@ -2226,7 +2226,7 @@ fn decode_bc1_color(dst: &mut [RGBA], source: &[u8]) {
     let g1: u16 = p[1].g as u16;
     let b1: u16 = p[1].b as u16;
 
-    if col.c0 > col.c1 {
+    if col.c0 > col.c1 || separate_alpha {
         p[2].r = ((2 * r0 + 1 * r1) / 3) as u8;
         p[2].g = ((2 * g0 + 1 * g1) / 3) as u8;
         p[2].b = ((2 * b0 + 1 * b1) / 3) as u8;


### PR DESCRIPTION
Fixes #1 